### PR TITLE
Added CMake script and MSVC fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.12)
+project(meta_enum)
+
+set(CMAKE_CXX_STANDARD 17)
+
+set(LIB_NAME ${PROJECT_NAME})
+
+# Create target and add include path
+add_library(${LIB_NAME} INTERFACE)
+add_library(${LIB_NAME}::${LIB_NAME} ALIAS ${LIB_NAME})
+
+# Add include directory to library
+set(INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_include_directories(
+    ${PROJECT_NAME}
+    INTERFACE
+    $<BUILD_INTERFACE:${INCLUDE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+

--- a/include/meta_enum.hpp
+++ b/include/meta_enum.hpp
@@ -99,7 +99,7 @@ constexpr std::string_view parseEnumMemberName(std::string_view memberString)
 
     size_t nameSize = 0;
 
-    while(isAllowedIdentifierChar(memberString[nameStart + nameSize]))
+    while((nameStart + nameSize) < memberString.size() && isAllowedIdentifierChar(memberString[nameStart + nameSize]))
     {
         ++nameSize;
     }


### PR DESCRIPTION
Small fix to parseEnumMemberName() to allow compiling to work on newest MSVC.

Added simple CMake script to make it easier to add library to another project.

Signed-off-by: Nils Petter Skålerud <np_skalerud@hotmail.com>